### PR TITLE
Sec 10.4.6.8.1: fix assertion on deferred field

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -116,7 +116,7 @@ contributors: Nicolò Ribaudo
           </h1>
           <dl class="header"></dl>
           <emu-alg>
-            1. Assert: _O_.[[Deferred]] is *false*.
+            1. Assert: _O_.[[Deferred]] is *true*.
             1. Let _m_ be _O_.[[Module]].
             1. If _m_ is a Cyclic Module Record, _m_.[[Status]] is not ~evaluated~, and ReadyForSyncExecution(_m_) is *false*, throw a *TypeError* exception.
             1. Perform ? EvaluateSync(_m_).


### PR DESCRIPTION
I think this assertion for `EnsureDeferredNamespaceEvaluation ( O )` should check the deferred field is `true` rather than `false`, as the only call site (10.4.6.8) guards that it's true.